### PR TITLE
Optimize dockerfile of ui

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10-alpine
+FROM mhart/alpine-node:6
 MAINTAINER Kyle Bai <kyle.b@inwinstack.com>
 
 RUN apk add --no-cache git bash && \


### PR DESCRIPTION
* Use mhart/alpine-node:6 images to build smaller than node:6.10-alpine
* The capacity of image from 142 MB to 140 MB